### PR TITLE
Adding "Disable Bluetooth" option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId 'com.apps.adrcotfas.goodtime'
         minSdkVersion 17

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
@@ -21,6 +21,7 @@ public class Preferences {
     private static final String SESSIONS_BEFORE_LONG_BREAK = "pref_sessionsBeforeLongBreak";
     private static final String SETTINGS_VERSION = "pref_settings_version";
     private static final String DISABLE_WIFI = "pref_disableWifi";
+    private static final String DISABLE_BLUETOOTH = "pref_disableBluetooth";
     private static final String KEEP_SCREEN_ON = "pref_keepScreenOn";
     private static final String CONTINUOUS_MODE = "pref_continuousMode";
     private static final String NOTIFICATION_VIBRATE = "pref_vibrate";
@@ -64,6 +65,10 @@ public class Preferences {
 
     boolean getDisableWifi() {
         return mPref.getBoolean(DISABLE_WIFI, true);
+    }
+
+    boolean getDisableBluetooth() {
+        return mPref.getBoolean(DISABLE_BLUETOOTH, true);
     }
 
     boolean getContinuousMode() {
@@ -113,6 +118,7 @@ public class Preferences {
              .putBoolean(KEEP_SCREEN_ON, oldPref.getBoolean(KEEP_SCREEN_ON, false))
              .putBoolean(DISABLE_SOUND_AND_VIBRATION, oldPref.getBoolean(DISABLE_SOUND_AND_VIBRATION, false))
              .putBoolean(DISABLE_WIFI, oldPref.getBoolean(DISABLE_WIFI, true))
+             .putBoolean(DISABLE_BLUETOOTH, oldPref.getBoolean(DISABLE_BLUETOOTH, true))
              .putBoolean(CONTINUOUS_MODE, oldPref.getBoolean(CONTINUOUS_MODE, false))
              .putBoolean(NOTIFICATION_VIBRATE, oldPref.getBoolean(NOTIFICATION_VIBRATE, true))
              .putBoolean(LANDSCAPE_MODE, oldPref.getBoolean(LANDSCAPE_MODE, false))

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
@@ -5,6 +5,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -50,6 +51,7 @@ public class TimerService extends Service {
     private LocalBroadcastManager mBroadcastManager;
     private int mPreviousRingerMode;
     private boolean mPreviousWifiMode;
+    private boolean mPreviousBluetoothMode;
     private Preferences mPref;
     private SessionType mCurrentSession;
 
@@ -99,6 +101,11 @@ public class TimerService extends Service {
             disableWifi();
         }
 
+        if (mPref.getDisableBluetooth() && sessionType == WORK) {
+            saveCurrentStateOfBluetooth();
+            disableBluetooth();
+        }
+
         mTimerState = ACTIVE;
         mCurrentSession = sessionType;
         setAlarm(mCountDownFinishedTime);
@@ -114,6 +121,9 @@ public class TimerService extends Service {
         }
         if (mPref.getDisableWifi()) {
             restoreWifi();
+        }
+        if (mPref.getDisableBluetooth()) {
+            restoreBluetooth();
         }
         if (mCurrentSession == LONG_BREAK) {
             resetCurrentSessionStreak();
@@ -158,6 +168,9 @@ public class TimerService extends Service {
         if (mPref.getDisableSoundAndVibration()) {
             restoreSound();
         }
+        if (mPref.getDisableBluetooth()) {
+            restoreBluetooth();
+        }
         if (mPref.getDisableWifi()) {
             restoreWifi();
         }
@@ -178,6 +191,11 @@ public class TimerService extends Service {
         mPreviousWifiMode = wifiManager.isWifiEnabled();
     }
 
+    private void saveCurrentStateOfBluetooth() {
+        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        mPreviousBluetoothMode = mBluetoothAdapter.isEnabled();
+    }
+
     private void disableSound() {
         Log.d(TAG, "Disabling sound");
         AudioManager aManager = (AudioManager) getSystemService(AUDIO_SERVICE);
@@ -190,6 +208,12 @@ public class TimerService extends Service {
         wifiManager.setWifiEnabled(false);
     }
 
+    private void disableBluetooth() {
+        Log.d(TAG, "Disabling Bluetooth");
+        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        mBluetoothAdapter.disable();
+    }
+
     private void restoreSound() {
         Log.d(TAG, "Restoring sound mode");
         AudioManager aManager = (AudioManager) getSystemService(AUDIO_SERVICE);
@@ -200,6 +224,14 @@ public class TimerService extends Service {
         Log.d(TAG, "Restoring Wifi mode");
         WifiManager wifiManager = (WifiManager) this.getSystemService(WIFI_SERVICE);
         wifiManager.setWifiEnabled(mPreviousWifiMode);
+    }
+
+    private void restoreBluetooth() {
+        Log.d(TAG, "Restoring Bluetooth mode");
+        if (mPreviousBluetoothMode) {
+            BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+            mBluetoothAdapter.enable();
+        }
     }
 
     private void sendFinishedNotification(boolean addButtons) {

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
@@ -175,6 +175,19 @@ public class TimerService extends Service {
             restoreWifi();
         }
 
+        if (mPreviousWifiMode && mPref.getDisableWifi()) {
+            while (!checkWifiEnabled()) {
+                SystemClock.sleep(1000);
+            }
+        }
+        if (mPreviousBluetoothMode && mPref.getDisableBluetooth()) {
+            while (!checkBluetoothEnabled()) {
+                SystemClock.sleep(1000);
+            }
+            Log.d(TAG, "Waiting 3 seconds");
+            SystemClock.sleep(3000);
+        }
+
         sendFinishedNotification(!mPref.getContinuousMode());
 
         mTimerState = INACTIVE;
@@ -232,6 +245,18 @@ public class TimerService extends Service {
             BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
             mBluetoothAdapter.enable();
         }
+    }
+
+    private boolean checkWifiEnabled() {
+        Log.d(TAG, "Check WiFi is restored");
+        WifiManager wifiManager = (WifiManager) this.getSystemService(WIFI_SERVICE);
+        return wifiManager.isWifiEnabled();
+    }
+
+    private boolean checkBluetoothEnabled() {
+        Log.d(TAG, "Check Bluetooth is restored");
+        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        return mBluetoothAdapter.isEnabled();
     }
 
     private void sendFinishedNotification(boolean addButtons) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -45,6 +45,7 @@
     <string name="pref_counter">"Выполнено сессий"</string>
     <string name="pref_disable_sound">"Отключить звук и вибрацию"</string>
     <string name="pref_disable_wifi">"Отключить Wi-Fi"</string>
+    <string name="pref_disable_bluetooth">"Отключить Bluetooth"</string>
     <string name="pref_fullscreen">"Полный экран"</string>
     <string name="pref_grant_permission">"Нажмите для предоставления разрешения"</string>
     <string name="pref_header_general">"Сессии"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="pref_counter">"Sessions counter"</string>
     <string name="pref_disable_sound">"Disable sound and vibration"</string>
     <string name="pref_disable_wifi">"Disable Wi-Fi"</string>
+    <string name="pref_disable_bluetooth">"Disable Bluetooth"</string>
     <string name="pref_fullscreen">"Fullscreen mode"</string>
     <string name="pref_grant_permission">"Click to grant permission"</string>
     <string name="pref_header_general">"Sessions"</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -89,6 +89,10 @@
       android:key="pref_disableWifi"
       android:title="@string/pref_disable_wifi" />
     <CheckBoxPreference
+      android:defaultValue="true"
+      android:key="pref_disableBluetooth"
+      android:title="@string/pref_disable_bluetooth" />
+    <CheckBoxPreference
       android:defaultValue="false"
       android:key="pref_keepScreenOn"
       android:title="@string/pref_keep_screen_on" />

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 		classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 20 11:06:12 EEST 2017
+#Mon Nov 06 04:35:28 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Hi guys!
I'm really enjoying your app! It's simple and has my favorite option "Disable WiFi" (I didn't find this function in other similar Android apps). And I've implemented feature "Disable Bluetooth" to your app.
What's the point: now a lot of people use smartwatches, wristbands and etc (in my case it's Xiaomi Mi Band 2). When your app is working, it cancels any noise from my phone. However, the notifications come to my band! That's why turning off Bluetooth during work session time is needed. Also, using your app with wearable devices is really useful, cause I often work in headphones in the office, and vibration from band is the one possible notification from your app to me.
Actually, I'm not Android developer (today was my first experience with Android ;), so, please, carefully review my patches. Especially, I don't know why some gradle files are changed...
The second patch could be not so clear.  I added checking bluetooth is really enabled and 3 seconds of delay. The thing is Bluetooth service needs some time for starting and connecting to devices. Without this checking and delay notification from Goodtime wouldn't receive to the band (notification comes first, but band hasn't connected to smartphone yet) and a user can miss session finish! However, this behavior with notification delay isn't so clear for a user (now notification appears after ~6 seconds: 3 seconds for starting bluetooth and 3 seconds of delay). You can reject this patch or add new option like "turn delay" or "smartwatches mode"... I can't come up with something simple and clear for a user. 