### PR TITLE
Set 'Add Session' session time to current time.

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Statistics/AllSessions/AddEditEntryDialogViewModel.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Statistics/AllSessions/AddEditEntryDialogViewModel.java
@@ -27,7 +27,7 @@ public class AddEditEntryDialogViewModel extends ViewModel {
     public long sessionToEditId;
 
     public AddEditEntryDialogViewModel() {
-        date.setValue(new DateTime().withHourOfDay(9).withMinuteOfHour(0));
+        date.setValue(new DateTime());
         label.setValue(null);
         sessionToEditId = INVALID_SESSION_TO_EDIT_ID;
     }


### PR DESCRIPTION
When adding a new session it's most often (always) because I missed starting one. This means I then have to set the session time to the current time instead of it (previously, by default) arbitrarily being set to 9am of today.