### PR TITLE
Give choice of different vibration patterns

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/BL/PreferenceHelper.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/BL/PreferenceHelper.java
@@ -46,7 +46,7 @@ public class PreferenceHelper {
     public final static String INSISTENT_RINGTONE          = "pref_ringtone_insistent";
     public final static String RINGTONE_WORK_FINISHED      = "pref_ringtone";
     public final static String RINGTONE_BREAK_FINISHED     = "pref_ringtone_break";
-    private final static String ENABLE_VIBRATE              = "pref_vibrate";
+    private final static String VIBRATION_TYPE             = "pref_vibration_type";
     private final static String ENABLE_FULLSCREEN           = "pref_fullscreen";
     public final static String DISABLE_SOUND_AND_VIBRATION = "pref_disable_sound_and_vibration";
     private final static String DISABLE_WIFI                = "pref_disable_wifi";
@@ -135,9 +135,17 @@ public class PreferenceHelper {
                 .getString(RINGTONE_BREAK_FINISHED, "");
     }
 
-    static boolean isVibrationEnabled() {
-        return getDefaultSharedPreferences(GoodtimeApplication.getInstance())
-                .getBoolean(ENABLE_VIBRATE, true);
+    static VibrationType getVibrationType() {
+        VibrationType type = VibrationType.STRONG;
+        try {
+            type = VibrationType.valueOf(
+                getDefaultSharedPreferences(GoodtimeApplication.getInstance())
+                        .getString(VIBRATION_TYPE, "")
+            );
+        } catch (IllegalArgumentException e) {
+            // Fall back invalid values to "STRONG"
+        }
+        return type;
     }
 
     public static boolean isFullscreenEnabled() {

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/BL/RingtoneAndVibrationPlayer.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/BL/RingtoneAndVibrationPlayer.java
@@ -53,9 +53,19 @@ class RingtoneAndVibrationPlayer extends ContextWrapper{
                 mMediaPlayer.start();
             });
 
-            if (PreferenceHelper.isVibrationEnabled()) {
-                mVibrator.vibrate(new long[] {0, 500, 500, 500},
-                        PreferenceHelper.isRingtoneInsistent() ? 2 : -1);
+            switch (PreferenceHelper.getVibrationType()) {
+                case STRONG:
+                    mVibrator.vibrate(new long[] {0, 500, 500, 500},
+                            PreferenceHelper.isRingtoneInsistent() ? 2 : -1);
+                    break;
+
+                case SOFT:
+                    mVibrator.vibrate(new long[] {0, 50, 50, 50, 50, 50},
+                            PreferenceHelper.isRingtoneInsistent() ? 2 : -1);
+                    break;
+
+                default:
+                    // Either "NONE" or an invalid value: no vibration
             }
         } catch (SecurityException | IOException e) {
             stop();

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/BL/VibrationType.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/BL/VibrationType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016-2019 Adrian Cotfas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.apps.adrcotfas.goodtime.BL;
+
+public enum VibrationType {
+    STRONG,
+    SOFT,
+    NONE
+}

--- a/app/src/main/res/values/spinners.xml
+++ b/app/src/main/res/values/spinners.xml
@@ -41,4 +41,16 @@
         <item>@string/spinner_range_hours</item>
     </string-array>
 
+    <string-array name="pref_vibration_types">
+        <item>@string/pref_vibration_type_none</item>
+        <item>@string/pref_vibration_type_soft</item>
+        <item>@string/pref_vibration_type_strong</item>
+    </string-array>
+
+    <string-array name="pref_vibration_values">
+        <item>NONE</item>
+        <item>SOFT</item>
+        <item>STRONG</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="pref_sessions_before_long_break">"Sessions before a long break"</string>
     <string name="pref_enable_long_break">"Enable long breaks"</string>
     <string name="pref_vibrate">"Vibration"</string>
+    <string name="pref_vibration_type_none">None</string>
+    <string name="pref_vibration_type_soft">Soft</string>
+    <string name="pref_vibration_type_strong">Strong</string>
     <string name="pref_amoled">"Dark theme"</string>
     <string name="pref_header_during_work_sessions">During work sessions</string>
     <string name="pref_enable_ringtone">"Notification sound"</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -104,10 +104,13 @@
             app:pref_summaryHasRingtone="%s"
             app:iconSpaceReserved="false"/>
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="pref_vibrate"
+        <ListPreference
+            android:defaultValue="STRONG"
+            android:entryValues="@array/pref_vibration_values"
+            android:entries="@array/pref_vibration_types"
+            android:key="pref_vibration_type"
             android:title="@string/pref_vibrate"
+            android:summary="%s"
             app:iconSpaceReserved="false"/>
 
         <CheckBoxPreference


### PR DESCRIPTION
While working in a shared space, I find that the vibration pattern is currently too long (1.5s) with impulses that are too strong (.5s each), which may disturb coworkers.

This commit adds a new preference allowing the user to choose between several vibration patterns. Available choices are: _“strong”_, the default vibration pattern from previous commits; _“soft”_, a new pattern with three short (.05s each) impulses; and _“none”_ which disables vibration.  As this is a highly subjective matter, new patterns could be added in the future.

The `pref_vibrate` preference is removed and replaced by a `pref_vibration_type` preference which is mapped to the new `VibrationType` enum’s values. In the settings screen, the switch preference widget is replaced by a list preference for choosing among patterns that are available.

***

I don’t have a lot of experience in Android dev so even though I did my best not to break anything there are probably some errors in there. In any case, thank you for your work on this app, it’s really useful to me and I’m sure to many others!